### PR TITLE
Fix redundant import

### DIFF
--- a/photo_editor/editor.py
+++ b/photo_editor/editor.py
@@ -2,10 +2,9 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from PIL import Image, ImageEnhance, ImageFilter, ImageDraw
-from PIL import Image, ImageEnhance, ImageFilter
 
 
 def brighten(image: Image.Image, factor: float = 1.2) -> Image.Image:


### PR DESCRIPTION
## Summary
- remove duplicate PIL import from `editor.py`
- drop unused typing import

## Testing
- `python -m py_compile photo_editor/editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68569c38928c8327be44de0231855d75