### PR TITLE
Fix __all__ definition

### DIFF
--- a/photo_editor/__init__.py
+++ b/photo_editor/__init__.py
@@ -7,11 +7,10 @@ applying basic edits, storing presets and interacting with simple AI helpers.
 # Re-export frequently used classes at the package level for convenience
 from .catalog import Catalog, MultiCatalog
 
+# Export commonly used classes and modules at the package level
 __all__ = [
     "Catalog",
     "MultiCatalog",
-=======
-__all__ = [
     "catalog",
     "editor",
     "presets",


### PR DESCRIPTION
## Summary
- fix merge conflict markers in `photo_editor/__init__.py`
- combine exports into a single `__all__` list

## Testing
- `python -m py_compile photo_editor/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68569c3717f08327babcc99b624d4bb2