### PR TITLE
Add simple Tkinter GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ professional tools like Photoshop or Lightroom.
 - Apply basic edits such as brightness, denoise and HSL adjustments
 - Save and load presets
 - Simple AI assistant that can suggest hashtags
+- Sleek GUI for interactive editing
 
 ## Usage
 
@@ -39,6 +40,14 @@ AI assistant. Add `--ask` to display stylistic questions before processing:
 
 ```
 python -m photo_editor.cli folder --auto-suggest --ask
+```
+
+### Graphical interface
+
+You can also launch a simple GUI to manually preview and edit images:
+
+```
+python -m photo_editor.gui
 ```
 
 Presets are stored in a `presets` folder inside the catalog directory as JSON

--- a/photo_editor/__init__.py
+++ b/photo_editor/__init__.py
@@ -6,6 +6,7 @@ applying basic edits, storing presets and interacting with simple AI helpers.
 
 # Re-export frequently used classes at the package level for convenience
 from .catalog import Catalog, MultiCatalog
+from . import gui
 
 # Export commonly used classes and modules at the package level
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "editor",
     "presets",
     "ai",
+    "gui",
 ]

--- a/photo_editor/gui.py
+++ b/photo_editor/gui.py
@@ -1,0 +1,108 @@
+"""Simple graphical interface for the photo editor."""
+
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from PIL import Image, ImageTk
+
+from .catalog import Catalog
+from .editor import Editor, brighten, denoise
+
+
+class EditorApp(tk.Tk):
+    """Tkinter based image editor."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Photo Editor")
+        self.geometry("600x600")
+        self.catalog: Catalog | None = None
+        self.images: list[Image.Image] = []
+        self.current_index = 0
+        self.editor: Editor | None = None
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        top = ttk.Frame(self)
+        top.pack(pady=5)
+        ttk.Button(top, text="Open Folder", command=self.open_folder).pack(side=tk.LEFT, padx=5)
+        ttk.Button(top, text="Save As...", command=self.save_image).pack(side=tk.LEFT)
+
+        self.image_label = ttk.Label(self)
+        self.image_label.pack(expand=True)
+
+        controls = ttk.Frame(self)
+        controls.pack(fill=tk.X, padx=10, pady=5)
+        ttk.Label(controls, text="Brightness").pack(anchor=tk.W)
+        self.brightness = tk.DoubleVar(value=1.0)
+        ttk.Scale(controls, from_=0.5, to=1.5, orient=tk.HORIZONTAL, variable=self.brightness).pack(fill=tk.X)
+        self.denoise_var = tk.IntVar(value=0)
+        ttk.Checkbutton(controls, text="Denoise", variable=self.denoise_var).pack(anchor=tk.W)
+        ttk.Button(controls, text="Apply", command=self.apply_edits).pack(pady=4)
+
+        nav = ttk.Frame(self)
+        nav.pack(pady=5)
+        ttk.Button(nav, text="<< Prev", command=self.prev_image).grid(row=0, column=0, padx=5)
+        ttk.Button(nav, text="Next >>", command=self.next_image).grid(row=0, column=1, padx=5)
+
+    def open_folder(self) -> None:
+        folder = filedialog.askdirectory()
+        if not folder:
+            return
+        self.catalog = Catalog(path=Path(folder))
+        self.catalog.load()
+        self.images = list(self.catalog)
+        if not self.images:
+            messagebox.showerror("Error", "No images found")
+            return
+        self.current_index = 0
+        self.load_image()
+
+    def load_image(self) -> None:
+        img = self.images[self.current_index]
+        self.editor = Editor(image=img.copy())
+        self._show_image(self.editor.image)
+
+    def _show_image(self, img: Image.Image) -> None:
+        disp = img.copy()
+        disp.thumbnail((500, 500))
+        self.tk_image = ImageTk.PhotoImage(disp)
+        self.image_label.configure(image=self.tk_image)
+
+    def apply_edits(self) -> None:
+        if not self.editor:
+            return
+        self.editor.image = self.images[self.current_index].copy()
+        if self.brightness.get() != 1.0:
+            self.editor.apply(brighten, self.brightness.get())
+        if self.denoise_var.get():
+            self.editor.apply(denoise)
+        self._show_image(self.editor.image)
+
+    def save_image(self) -> None:
+        if not self.editor:
+            return
+        path = filedialog.asksaveasfilename(defaultextension=".jpg")
+        if not path:
+            return
+        self.editor.save(Path(path))
+
+    def prev_image(self) -> None:
+        if self.current_index > 0:
+            self.current_index -= 1
+            self.load_image()
+
+    def next_image(self) -> None:
+        if self.current_index < len(self.images) - 1:
+            self.current_index += 1
+            self.load_image()
+
+
+def main() -> None:
+    app = EditorApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a Tkinter-based GUI in `photo_editor.gui`
- expose the GUI module in `photo_editor.__init__`
- mention the new interface in `README`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m photo_editor.cli --help` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68569d0d2b8483278b7e9e9942fcf3d6