### PR TITLE
Fix CLI catalog and preset handling

### DIFF
--- a/photo_editor/cli.py
+++ b/photo_editor/cli.py
@@ -55,12 +55,8 @@ def main() -> None:
         catalog = MultiCatalog(paths=args.catalog)
     catalog.load()
 
-    preset_folder = args.catalog[0] if len(args.catalog) == 1 else args.catalog[0]
+    preset_folder = args.catalog[0]
     presets = PresetLibrary(folder=preset_folder / "presets")
-    catalog = Catalog(path=args.catalog)
-    catalog.load()
-
-    presets = PresetLibrary(folder=args.catalog / "presets")
     presets.load()
 
     engine = AIEngine()


### PR DESCRIPTION
## Summary
- remove duplicate catalog initialization logic in `cli.py`
- simplify preset loading

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68569f8be2948327b0b7828f80909b20